### PR TITLE
Move unused dependencies to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,7 @@
     "postpack": "ember ts:clean"
   },
   "dependencies": {
-    "@embroider/macros": "^1.0.0",
-    "@glimmer/tracking": "^1.0.4",
-    "ember-auto-import": "^2.4.0",
     "ember-cli-babel": "^7.26.11",
-    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-typescript": "^4.2.1"
   },
   "devDependencies": {
@@ -41,7 +37,9 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@ember/test-waiters": "^3.0.1",
+    "@embroider/macros": "^1.0.0",
     "@embroider/test-setup": "^1.0.0",
+    "@glimmer/tracking": "^1.0.4",
     "@nullvoxpopuli/eslint-configs": "^2.1.18",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
@@ -75,6 +73,7 @@
     "ember-auto-import": "^2.4.0",
     "ember-cli": "~4.1.1",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.2",


### PR DESCRIPTION
Minor thing but these 4 deps not used by the addon at run time hence don't need to be listed in `dependencies`.

Not a big deal but for large apps with tons of dependencies this matters as it affects build time (when `
ember-functions-as-helper-polyfill` would be included multiple times in the graph)