### PR TITLE
Remove unneeded peer declarations

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,6 +4,20 @@ const getChannelURL = require('ember-source-channel-url');
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
+  const ember3Deps = {
+    'ember-maybe-import-regenerator': '^1.0.0',
+    'ember-qunit': '^5.1.5',
+    '@ember/test-waiters': '^2.4.5',
+    '@ember/test-helpers': '^2.6.0',
+    'ember-resolver': '^8.0.3',
+    // Compat Upgrades
+    'ember-cli': '~4.12.0',
+    'ember-auto-import': '^2.10.0',
+    // Not needed
+    'ember-fetch': null,
+    'ember-cli-app-version': null,
+  };
+
   return {
     usePnpm: true,
     scenarios: [
@@ -11,6 +25,7 @@ module.exports = async function () {
         name: 'ember-3.25',
         npm: {
           devDependencies: {
+            ...ember3Deps,
             'ember-source': '~3.25.0',
           },
         },
@@ -18,6 +33,7 @@ module.exports = async function () {
       {
         name: 'ember-3.28-lts',
         npm: {
+          ...ember3Deps,
           devDependencies: {
             'ember-source': '~3.28.0',
           },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-cli-htmlbars": "^6.0.1",
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-disable-prototype-extensions": "^1.1.3",
-    "ember-load-initializers": "^2.1.2",
+    "ember-load-initializers": "^3.0.1",
     "ember-page-title": "^7.0.0",
     "ember-qunit": "^9.0.0",
     "ember-resolver": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -100,9 +100,6 @@
     "typescript": "^4.6.3",
     "webpack": "^5.68.0"
   },
-  "peerDependencies": {
-    "ember-source": "^3.25.0 || >=4.0.0"
-  },
   "packageManager": "pnpm@10.10.0",
   "engines": {
     "node": ">= 14.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       ember-load-initializers:
-        specifier: ^2.1.2
-        version: 2.1.2(@babel/core@7.27.1)
+        specifier: ^3.0.1
+        version: 3.0.1(ember-source@4.2.0(@babel/core@7.27.1)(@glint/template@1.5.2)(webpack@5.99.8))
       ember-page-title:
         specifier: ^7.0.0
         version: 7.0.0
@@ -712,11 +712,6 @@ packages:
   '@babel/plugin-transform-typescript@7.27.1':
     resolution: {integrity: sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==}
     engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-typescript@7.4.5':
-    resolution: {integrity: sha512-RPB/YeGr4ZrFKNwfuQRlMf2lxoCUaU01MTw39/OFE/RiL8HDjtn68BwEPft1P7JN4akyEmjGWAMNldOV7o9V2g==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -2759,10 +2754,6 @@ packages:
   ember-cli-string-utils@1.1.0:
     resolution: {integrity: sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==}
 
-  ember-cli-typescript@2.0.2:
-    resolution: {integrity: sha512-7I5azCTxOgRDN8aSSnJZIKSqr+MGnT+jLTUbBYqF8wu6ojs2DUnTePxUcQMcvNh3Q3B1ySv7Q/uZFSjdU9gSjA==}
-    engines: {node: 6.* || 8.* || >= 10.*}
-
   ember-cli-typescript@3.0.0:
     resolution: {integrity: sha512-lo5YArbJzJi5ssvaGqTt6+FnhTALnSvYVuxM7lfyL1UCMudyNJ94ovH5C7n5il7ATd6WsNiAPRUO/v+s5Jq/aA==}
     engines: {node: 8.* || >= 10.*}
@@ -2800,9 +2791,11 @@ packages:
     resolution: {integrity: sha512-SB9NcZ27OtoUk+gfalsc3QU17+54OoqR668qHcuvHByk4KAhGxCKlkm9EBlKJcGr7yceOOAJqohTcCEBqfRw9g==}
     engines: {node: '>= 0.10.0'}
 
-  ember-load-initializers@2.1.2:
-    resolution: {integrity: sha512-CYR+U/wRxLbrfYN3dh+0Tb6mFaxJKfdyz+wNql6cqTrA0BBi9k6J3AaKXj273TqvEpyyXegQFFkZEiuZdYtgJw==}
-    engines: {node: 6.* || 8.* || >= 10.*}
+  ember-load-initializers@3.0.1:
+    resolution: {integrity: sha512-qV3vxJKw5+7TVDdtdLPy8PhVsh58MlK8jwzqh5xeOwJPNP7o0+BlhvwoIlLYTPzGaHdfjEIFCgVSyMRGd74E1g==}
+    engines: {node: '>= 18.*'}
+    peerDependencies:
+      ember-source: '>= 5'
 
   ember-page-title@7.0.0:
     resolution: {integrity: sha512-oq6+HYbeVD/BnxIO5AkP4gWlsatdgW2HFO10F8+XQiJZrwa7cC7Wm54JNGqQkavkDQTgNSiy1Fe2NILJ14MmAg==}
@@ -7102,12 +7095,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-typescript@7.4.5(@babel/core@7.27.1)':
-    dependencies:
-      '@babel/core': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.27.1)
-
   '@babel/plugin-transform-typescript@7.5.5(@babel/core@7.27.1)':
     dependencies:
       '@babel/core': 7.27.1
@@ -9872,24 +9859,6 @@ snapshots:
 
   ember-cli-string-utils@1.1.0: {}
 
-  ember-cli-typescript@2.0.2(@babel/core@7.27.1):
-    dependencies:
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.27.1)
-      '@babel/plugin-transform-typescript': 7.4.5(@babel/core@7.27.1)
-      ansi-to-html: 0.6.15
-      debug: 4.4.0
-      ember-cli-babel-plugin-helpers: 1.1.1
-      execa: 1.0.0
-      fs-extra: 7.0.1
-      resolve: 1.22.10
-      rsvp: 4.8.5
-      semver: 6.3.1
-      stagehand: 1.0.1
-      walk-sync: 1.1.4
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   ember-cli-typescript@3.0.0(@babel/core@7.27.1):
     dependencies:
       '@babel/plugin-transform-typescript': 7.5.5(@babel/core@7.27.1)
@@ -10117,13 +10086,9 @@ snapshots:
 
   ember-disable-prototype-extensions@1.1.3: {}
 
-  ember-load-initializers@2.1.2(@babel/core@7.27.1):
+  ember-load-initializers@3.0.1(ember-source@4.2.0(@babel/core@7.27.1)(@glint/template@1.5.2)(webpack@5.99.8)):
     dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-typescript: 2.0.2(@babel/core@7.27.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
+      ember-source: 4.2.0(@babel/core@7.27.1)(@glint/template@1.5.2)(webpack@5.99.8)
 
   ember-page-title@7.0.0:
     dependencies:


### PR DESCRIPTION
embroider, auto-import, and ember-cli before them handled virtual deps without a package.json entry.

package.json entries win over virtual deps, so we don't want to declare ember-source or @glimmer/tracking as peers.


Related:
- https://github.com/ember-polyfills/ember-functions-as-helper-polyfill/pull/151
- https://github.com/jelhan/ember-style-modifier/pull/312
- https://github.com/jmurphyau/ember-truth-helpers/pull/211
- https://github.com/ember-modifier/ember-modifier/pull/949
- https://github.com/tracked-tools/tracked-toolbox/pull/211
- https://github.com/emberjs/ember-test-helpers/pull/1543
- https://github.com/NullVoxPopuli/ember-resources/pull/1189
- https://github.com/NullVoxPopuli/ember-modify-based-class-resource/pull/20
- https://github.com/universal-ember/kolay/pull/187
- https://github.com/universal-ember/reactiveweb/pull/139
- https://github.com/universal-ember/ember-primitives/pull/471
- https://github.com/universal-ember/docs-support/pull/77
